### PR TITLE
Possible temporary fix for screen hang.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Changes by devsfan1830: Implemented the hanging workaround here "https://github.com/mcuadros/OctoPrint-TFT/issues/34#issuecomment-417065437"
+
+
 OctoPrint-TFT [![GitHub release](https://img.shields.io/github/release/mcuadros/OctoPrint-TFT.svg)](https://github.com/mcuadros/OctoPrint-TFT/releases) [![license](https://img.shields.io/github/license/mcuadros/OctoPrint-TFT.svg)]()
 =============
 ### My changes to the original software (I'm also working on some bugs):

--- a/ui/status.go
+++ b/ui/status.go
@@ -96,7 +96,7 @@ func (m *statusPanel) createInfoBox() *gtk.Box {
 
 func (m *statusPanel) createPrintButton() gtk.IWidget {
 	m.print = MustButton(MustImageFromFileWithSize("status.svg", 40, 40), func() {
-		defer m.updateTemperature()
+		//defer m.updateTemperature()
 
 		Logger.Warning("Starting a new job")
 		if err := (&octoprint.StartRequest{}).Do(m.UI.Printer); err != nil {
@@ -110,7 +110,7 @@ func (m *statusPanel) createPrintButton() gtk.IWidget {
 
 func (m *statusPanel) createPauseButton() gtk.IWidget {
 	m.pause = MustButton(MustImageFromFileWithSize("pause.svg", 40, 40), func() {
-		defer m.updateTemperature()
+		//defer m.updateTemperature()
 
 		Logger.Warning("Pausing/Resuming job")
 		cmd := &octoprint.PauseRequest{Action: octoprint.Toggle}
@@ -125,7 +125,7 @@ func (m *statusPanel) createPauseButton() gtk.IWidget {
 
 func (m *statusPanel) createStopButton() gtk.IWidget {
 	m.stop = MustButton(MustImageFromFileWithSize("stop.svg", 40, 40), func() {
-		defer m.updateTemperature()
+		//defer m.updateTemperature()
 
 		Logger.Warning("Stopping job")
 		if err := (&octoprint.CancelRequest{}).Do(m.UI.Printer); err != nil {
@@ -138,7 +138,7 @@ func (m *statusPanel) createStopButton() gtk.IWidget {
 }
 
 func (m *statusPanel) update() {
-	m.updateTemperature()
+	//m.updateTemperature()
 	m.updateJob()
 }
 


### PR DESCRIPTION
Noticed that in the discussion of issue 34 on the main github, someone figured out a workaround for the screen freezing during a print. I commented out the necessary lines and the freezing seems to have stopped. It removes the temperature readings in the print status but for me and im sure many others thats fine since the printers main LCD already shows that info.